### PR TITLE
Increase aggressiveness of farming to enable 1-shot kills more frequently

### DIFF
--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -1616,7 +1616,7 @@ function autoMap() {
         
         //Create siphonology on demand section.
         var siphlvl = game.global.world - game.portal.Siphonology.level;
-
+        debug("Checking Siphonology");
         if (getPageSetting('DynamicSiphonology')){
             for (siphlvl; siphlvl < game.global.world; siphlvl++) {
                 //check HP vs damage and find how many siphonology levels we need.

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -423,7 +423,7 @@ function autoHeirlooms() {
                 var styleIndex = 4 + (bestUpgrade.index * 3);
                 //enclose in backtic ` for template string $ stuff
                 document.getElementById('selectedHeirloom').childNodes[0].childNodes[styleIndex].style.backgroundColor = "lightblue";
-                document.getElementById('selectedHeirloom').childNodes[0].childNodes[styleIndex].setAttribute("onmouseover", `tooltip(\'Heirloom\', \"customText\", event, \'<div class=\"selectedHeirloomItem heirloomRare${loom.rarity}\"> AutoTrimps recommended upgrade for this item. </div>\'         )`);
+                document.getElementById('selectedHeirloom').childNodes[0].childNodes[styleIndex].setAttribute("onmouseover", 'tooltip(\'Heirloom\', \"customText\", event, \'<div class=\"selectedHeirloomItem heirloomRare${loom.rarity}\"> AutoTrimps recommended upgrade for this item. </div>\'         )');
                 document.getElementById('selectedHeirloom').childNodes[0].childNodes[styleIndex].setAttribute("onmouseout", 'tooltip(\'hide\')');
                 //lightblue = greyish
                 //swapClass("tooltipExtra", "tooltipExtraHeirloom", document.getElementById("tooltipDiv"));
@@ -1621,7 +1621,12 @@ function autoMap() {
             for (siphlvl; siphlvl < game.global.world; siphlvl++) {
                 //check HP vs damage and find how many siphonology levels we need.
                 var maphp = getEnemyMaxHealth(siphlvl);
-                if (baseDamage * 4 < maphp){
+                if(game.global.challengeActive == 'Crushed'){
+                	//In Crushed, keep the siphonology level down.
+                	if (baseDamage < maphp){
+                		break;
+                	}
+                }else if (baseDamage * 4 < maphp){
                     break;
                 }
             }

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -1616,15 +1616,12 @@ function autoMap() {
         
         //Create siphonology on demand section.
         var siphlvl = game.global.world - game.portal.Siphonology.level;
-        debug("Checking Siphonology");
         if (getPageSetting('DynamicSiphonology')){
             for (siphlvl; siphlvl < game.global.world; siphlvl++) {
                 //check HP vs damage and find how many siphonology levels we need.
                 var maphp = getEnemyMaxHealth(siphlvl);
-                debug("Siphonology Check: MyDmg: " + baseDamage + "     MapHP: " + maphp);
                 if(game.global.challengeActive == 'Crushed'){
                     //In Crushed, keep the siphonology level down.
-                    
                     if (baseDamage < maphp){
                         break;
                     }

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -1537,6 +1537,10 @@ function autoMap() {
             enemyHealth *= 2;
         }
         var pierceMod = 0;
+        if(game.global.challengeActive == 'Crushed'){
+            //For crushed, need to farm to ensure we are 1-hitting fairly consistently.  But, only want to farm if there are upgrades
+            shouldFarm = baseDamage < enemyHealth;
+        }
         if(game.global.challengeActive == 'Lead') {
             enemyDamage *= (1 + (game.challenges.Lead.stacks * 0.04));
             enemyHealth *= (1 + (game.challenges.Lead.stacks * 0.04));

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -1621,13 +1621,14 @@ function autoMap() {
             for (siphlvl; siphlvl < game.global.world; siphlvl++) {
                 //check HP vs damage and find how many siphonology levels we need.
                 var maphp = getEnemyMaxHealth(siphlvl);
+                debug("Siphonology Check: MyDmg: " + baseDamage + "     MapHP: " + maphp);
                 if(game.global.challengeActive == 'Crushed'){
-                	//In Crushed, keep the siphonology level down.
-                	debug("Siphonology Check: MyDmg: " + baseDamage + "     MapHP: " + maphp);
-                	if (baseDamage < maphp){
-                		break;
-                	}
-                }else if (baseDamage * 4 < maphp){
+                    //In Crushed, keep the siphonology level down.
+                    
+                    if (baseDamage < maphp){
+                        break;
+                    }
+                }else if (baseDamage * 1 < maphp){
                     break;
                 }
             }

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -1623,6 +1623,7 @@ function autoMap() {
                 var maphp = getEnemyMaxHealth(siphlvl);
                 if(game.global.challengeActive == 'Crushed'){
                 	//In Crushed, keep the siphonology level down.
+                	debug("Siphonology Check: MyDmg: " + baseDamage + "     MapHP: " + maphp);
                 	if (baseDamage < maphp){
                 		break;
                 	}


### PR DESCRIPTION
Initially, the work here was exclusively for the crushed mode, but I found that in general, enabling siphonology to be more aggressive (easier to fire) when farming as a whole benefited beyond the crushed runs.  These updates should allow siphonology to be used to attempt to keep the game 1-shotting opponents both in the maps and in the world maps.
