### PR TITLE
Rewrote Dynamic Prestige

### DIFF
--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -2309,7 +2309,7 @@ function mainLoop() {
     else autoTrimpSettings.Prestige.selected = document.getElementById('Prestige').value; //if we dont want to, just make sure the UI setting and the internal setting are aligned.
 }
 
-//Change prestiges as we go (thanks to Hider, reworked by Hyppy)
+//Change prestiges as we go (reworked by Hyppy)
 //The idea is like this. We will stick to Dagger until the end of the run, then we will slowly start grabbing prestiges, so we can hit the Prestige we want by the last zone.
 //The keywords below "Dagadder" and "GambesOP" are merely representative of the minimum and maximum values. Toggling these on and off, the script will take care of itself, when set to min (Dagger) or max (Gambeson).
 //In this way, we will achieve the desired "maxPrestige" setting (which would be somewhere in the middle, like Polearm) by the end of the run. (instead of like in the past where it was gotten from the beginning and wasting time in early maps.)

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -2380,6 +2380,8 @@ function prestigeChanging(){
 		else if (lastzone - game.global.world == 4)
 			mapThreshold = 5;
 		
+		// Correcting for the logic of the script that only checks this while a map is underway
+		mapThreshold -= 1;
 		
 		if (game.global.mapBonus < mapThreshold)
             autoTrimpSettings.Prestige.selected = "GambesOP";

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -2391,7 +2391,7 @@ function prestigeChanging(){
     
     
     //If we are not in the prestige farming zone (the beginning of the run), use dagger:
-    if (game.global.world < lastzone-zonesToFarm || game.global.mapBonus == 10)  
+    if (game.global.world <= lastzone-zonesToFarm || game.global.mapBonus == 10)  
        autoTrimpSettings.Prestige.selected = "Dagadder";
 }
 

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -2330,7 +2330,7 @@ function prestigeChanging(){
     
 	// Find total prestiges needed by determining current prestiges versus the desired prestiges by the end of the run
 	var neededPrestige = 0;
-	for (i = 1; i < maxPrestigeIndex ; i++){
+	for (i = 1; i <= maxPrestigeIndex ; i++){
 		if (game.mapUnlocks[autoTrimpSettings.Prestige.list[i]].last <= lastzone){
 			// For Scientist IV bonus, halve the required prestiges to farm
 			if (game.global.sLevel > 3)

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -2330,7 +2330,7 @@ function prestigeChanging(){
     
 	// Find total prestiges needed by determining current prestiges versus the desired prestiges by the end of the run
 	var neededPrestige = 0;
-	for (i = 1; i <= maxPrestigeIndex ; i++){
+	for (i = 1; i < maxPrestigeIndex ; i++){
 		if (game.mapUnlocks[autoTrimpSettings.Prestige.list[i]].last <= lastzone){
 			// For Scientist IV bonus, halve the required prestiges to farm
 			if (game.global.sLevel > 3)


### PR DESCRIPTION
I reworked dynamic prestige to:
- Determine the number of prestiges needed based on last expected level and current prestige unlocks
- Account for Scientist IV and Lead for prestige gains and map farming
- Start by farming 4 maps per zone, ramping up to 9 maps farmed in the final zone.
- It re-analyzes after every map, to prevent overshooting by a significant amount

I tested this on the 3.6 server with Polearm as my prestige and my target zone at 255.

One option to change this may be to force 9 maps on the last zone even if we've hit the target prestige; the logic isn't quite perfect yet so overshooting is possible. The normal farming script should still kick in if attack is needed
