### PR TITLE
Update AutoTrimps2.js

### DIFF
--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -869,7 +869,7 @@ function evaluateEfficiency(equipName) {
             var NextEff = PrestigeValue(equip.Upgrade);
             //Scientist 3 and 4 challenge: set metalcost to Infinity so it can buy equipment levels without waiting for prestige. (fake the impossible science cost)
             //also Fake set the next cost to infinity so it doesn't wait for prestiges if you have both options disabled.
-            if ((game.global.challengeActive == "Scientist" && getScientistLevel() > 2) || (!getPageSetting('BuyArmorUpgrades') && !getPageSetting('BuyWeaponUpgrades')))
+            if ((game.global.challengeActive == "Scientist" && getScientistLevel() > 2) && (!getPageSetting('BuyArmorUpgrades') || !getPageSetting('BuyWeaponUpgrades')))
                 var NextCost = Infinity;
             else
                 var NextCost = Math.ceil(getNextPrestigeCost(equip.Upgrade) * Math.pow(1 - game.portal.Artisanistry.modifier, game.portal.Artisanistry.level));


### PR DESCRIPTION
Bugfix trigger condition with backwards and/or. Previously triggered if both upgrade buttons were toggled (regardless of challenge), _or_ scientist 3+ was active, which means it triggered all the time since both upgrade buttons are usually toggled.
